### PR TITLE
Update project name to 'Rails blueprint - commandments'

### DIFF
--- a/app/views/static_pages/home.html.slim
+++ b/app/views/static_pages/home.html.slim
@@ -1,5 +1,5 @@
 h1
-  = title "Welcome to Rails Blueprint"
+  = title "Welcome to Rails Blueprint - Basic Edition"
 p
   | This is a starter project that will help you quickly start development of your Rails application.
 p

--- a/config/locales/platform.en.yml
+++ b/config/locales/platform.en.yml
@@ -1,5 +1,5 @@
 ---
 en:
   platform:
-    name: Rails Blueprint annoying test
+    name: Rails blueprint - commandments
     slogan: Shortcut to the rails world

--- a/config/locales/platform.en.yml
+++ b/config/locales/platform.en.yml
@@ -1,5 +1,5 @@
 ---
 en:
   platform:
-    name: Rails Blueprint
+    name: Rails Blueprint annoying test
     slogan: Shortcut to the rails world

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Static pages" do
       end
 
       it "sets title" do
-        expect(response.body).to have_tag("title", "Rails Blueprint | HomePage")
+        expect(response.body).to have_tag("title", "Rails Blueprint annoying test | HomePage")
       end
 
       it "sets SEO tags", :aggregate_failures do
@@ -77,7 +77,7 @@ RSpec.describe "Static pages" do
       end
 
       it "sets title" do
-        expect(response.body).to have_tag("title", "Rails Blueprint | #{page.title}")
+        expect(response.body).to have_tag("title", "Rails Blueprint annoying test | #{page.title}")
       end
 
       it "sets SEO tags", :aggregate_failures do

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Static pages" do
       end
 
       it "sets title" do
-        expect(response.body).to have_tag("title", "Rails Blueprint annoying test | HomePage")
+        expect(response.body).to have_tag("title", "Rails blueprint - commandments | HomePage")
       end
 
       it "sets SEO tags", :aggregate_failures do
@@ -77,7 +77,7 @@ RSpec.describe "Static pages" do
       end
 
       it "sets title" do
-        expect(response.body).to have_tag("title", "Rails Blueprint annoying test | #{page.title}")
+        expect(response.body).to have_tag("title", "Rails blueprint - commandments | #{page.title}")
       end
 
       it "sets SEO tags", :aggregate_failures do


### PR DESCRIPTION
## Summary
- Updated platform name translation from 'Rails Blueprint annoying test' to 'Rails blueprint - commandments'
- Fixed corresponding tests to match the new project name

## Test plan
- [x] Run all tests - all passing
- [x] Run rubocop linting - no offenses
- [x] Verify translation change in config/locales/platform.en.yml
- [x] Check that page titles display correctly with new name