### PR TITLE
Add CI test for blueprint initialization process

### DIFF
--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -94,3 +94,60 @@ jobs:
         run: bundle exec bundle-audit
       - name: Audit impormaps for vulnerabilities
         run: bundle exec bin/importmap audit
+
+  blueprint-init:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: rbp_blueprint_init_test
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Install Yarn & modules
+        run: |
+          npm install -g yarn
+          yarn install
+      - name: Test blueprint initialization process
+        env:
+          RAILS_ENV: test
+          POSTGRES_HOST: localhost
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: rbp_blueprint_init_test
+          POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
+          APP_NAME: TestApp
+        run: |
+          echo "Testing blueprint:init task with APP_NAME=TestApp"
+          bundle exec rails blueprint:init
+          
+          echo "Verifying config files were created correctly"
+          test -f config/app_config.rb || { echo "app_config.rb not created"; exit 1; }
+          test -f config/app.yml || { echo "app.yml not created"; exit 1; }
+          test -f config/database.yml || { echo "database.yml not created"; exit 1; }
+          test -f config/cable.yml || { echo "cable.yml not created"; exit 1; }
+          test -f config/storage.yml || { echo "storage.yml not created"; exit 1; }
+          test -f package.json || { echo "package.json not created"; exit 1; }
+          test -f config/importmap.rb || { echo "importmap.rb not created"; exit 1; }
+          test -f config/i18n-tasks.yml || { echo "i18n-tasks.yml not created"; exit 1; }
+          
+          echo "Checking that APP_NAME was properly set in config files"
+          grep -q "TestApp" config/app.yml || { echo "APP_NAME not found in app.yml"; exit 1; }
+          
+          echo "Creating and migrating database with data migrations"
+          bundle exec rails db:create
+          bundle exec rails db:migrate:with_data
+          
+          echo "Verifying database setup completed successfully"
+          bundle exec rails runner "puts 'Database connection successful: #{ActiveRecord::Base.connection.active?}'"
+          
+          echo "Blueprint initialization test completed successfully"

--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -103,7 +103,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: rbp_blueprint_init_test
+          POSTGRES_DB: test_app_test
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
@@ -123,8 +123,9 @@ jobs:
           POSTGRES_HOST: localhost
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: rbp_blueprint_init_test
+          POSTGRES_DB: test_app_test
           POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
+          DATABASE_URL: postgresql://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/test_app_test
         run: |
           echo "Testing blueprint:init task with app_name=test_app"
           bundle exec rails blueprint:init[test_app]

--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -125,10 +125,9 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: rbp_blueprint_init_test
           POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
-          APP_NAME: TestApp
         run: |
-          echo "Testing blueprint:init task with APP_NAME=TestApp"
-          bundle exec rails blueprint:init
+          echo "Testing blueprint:init task with app_name=test_app"
+          bundle exec rails blueprint:init[test_app]
           
           echo "Verifying config files were created correctly"
           test -f config/app_config.rb || { echo "app_config.rb not created"; exit 1; }
@@ -140,8 +139,8 @@ jobs:
           test -f config/importmap.rb || { echo "importmap.rb not created"; exit 1; }
           test -f config/i18n-tasks.yml || { echo "i18n-tasks.yml not created"; exit 1; }
           
-          echo "Checking that APP_NAME was properly set in config files"
-          grep -q "TestApp" config/app.yml || { echo "APP_NAME not found in app.yml"; exit 1; }
+          echo "Checking that app_name was properly set in config files"
+          grep -q "test_app" config/app.yml || { echo "app_name not found in app.yml"; exit 1; }
           
           echo "Creating and migrating database with data migrations"
           bundle exec rails db:create


### PR DESCRIPTION
## Summary
- Add new GitHub Actions job to test the `rails blueprint:init` command
- Ensures the blueprint initialization process works correctly on every push/PR
- Prevents breaking the initial setup process that new users depend on

## What this tests
- Runs `rails blueprint:init[test_app]` with a test app name
- Verifies all required config files are created
- Checks that app_name is properly set in generated configs  
- Creates database and runs migrations with data
- Verifies database connection is successful

## Test plan
- [x] CI test added and passing in GitHub Actions
- [x] Verified YAML syntax is valid
- [x] Database connection properly configured for CI environment