### PR TITLE
Add spec to detect duplicate keys in locale files

### DIFF
--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -94,3 +94,60 @@ jobs:
         run: bundle exec bundle-audit
       - name: Audit impormaps for vulnerabilities
         run: bundle exec bin/importmap audit
+
+  blueprint-init:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: rbp_blueprint_init_test
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Install Yarn & modules
+        run: |
+          npm install -g yarn
+          yarn install
+      - name: Test blueprint initialization process
+        env:
+          RAILS_ENV: test
+          POSTGRES_HOST: localhost
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: rbp_blueprint_init_test
+          POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
+          APP_NAME: TestApp
+        run: |
+          echo "Testing blueprint:init task with APP_NAME=TestApp"
+          bundle exec rails blueprint:init
+          
+          echo "Verifying config files were created correctly"
+          test -f config/app_config.rb || { echo "app_config.rb not created"; exit 1; }
+          test -f config/app.yml || { echo "app.yml not created"; exit 1; }
+          test -f config/database.yml || { echo "database.yml not created"; exit 1; }
+          test -f config/cable.yml || { echo "cable.yml not created"; exit 1; }
+          test -f config/storage.yml || { echo "storage.yml not created"; exit 1; }
+          test -f package.json || { echo "package.json not created"; exit 1; }
+          test -f config/importmap.rb || { echo "importmap.rb not created"; exit 1; }
+          test -f config/i18n-tasks.yml || { echo "i18n-tasks.yml not created"; exit 1; }
+          
+          echo "Checking that APP_NAME was properly set in config files"
+          grep -q "TestApp" config/app.yml || { echo "APP_NAME not found in app.yml"; exit 1; }
+          
+          echo "Creating and migrating database with data migrations"
+          bundle exec rails db:create
+          bundle exec rails db:migrate:with_data
+          
+          echo "Verifying database setup completed successfully"
+          bundle exec rails runner "puts 'Database connection successful: #{ActiveRecord::Base.connection.active?}'"
+          
+          echo "Blueprint initialization test completed successfully"

--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -103,7 +103,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: rbp_blueprint_init_test
+          POSTGRES_DB: test_app_test
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
@@ -123,8 +123,9 @@ jobs:
           POSTGRES_HOST: localhost
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: rbp_blueprint_init_test
+          POSTGRES_DB: test_app_test
           POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
+          DATABASE_URL: postgresql://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/test_app_test
         run: |
           echo "Testing blueprint:init task with app_name=test_app"
           bundle exec rails blueprint:init[test_app]

--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -125,10 +125,9 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: rbp_blueprint_init_test
           POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
-          APP_NAME: TestApp
         run: |
-          echo "Testing blueprint:init task with APP_NAME=TestApp"
-          bundle exec rails blueprint:init
+          echo "Testing blueprint:init task with app_name=test_app"
+          bundle exec rails blueprint:init[test_app]
           
           echo "Verifying config files were created correctly"
           test -f config/app_config.rb || { echo "app_config.rb not created"; exit 1; }
@@ -140,8 +139,8 @@ jobs:
           test -f config/importmap.rb || { echo "importmap.rb not created"; exit 1; }
           test -f config/i18n-tasks.yml || { echo "i18n-tasks.yml not created"; exit 1; }
           
-          echo "Checking that APP_NAME was properly set in config files"
-          grep -q "TestApp" config/app.yml || { echo "APP_NAME not found in app.yml"; exit 1; }
+          echo "Checking that app_name was properly set in config files"
+          grep -q "test_app" config/app.yml || { echo "app_name not found in app.yml"; exit 1; }
           
           echo "Creating and migrating database with data migrations"
           bundle exec rails db:create

--- a/spec/i18n_duplicates_spec.rb
+++ b/spec/i18n_duplicates_spec.rb
@@ -1,0 +1,118 @@
+require "rails_helper"
+
+RSpec.describe "Locale files" do # rubocop:disable RSpec/DescribeClass
+  describe "duplicate keys detection" do
+    def find_duplicate_keys_with_line_numbers(file_path) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      duplicates = {}
+      current_path = []
+      line_number = 0
+      key_occurrences = Hash.new { |h, k| h[k] = [] }
+
+      File.foreach(file_path) do |line|
+        line_number += 1
+
+        # Skip empty lines and comments
+        next if line.strip.empty? || line.strip.start_with?("#")
+
+        # Calculate indentation level
+        line[/\A */].size
+
+        # Parse key-value pairs
+        if line =~ /^( *)([^:]+):\s*(.*)/
+          spaces = Regexp.last_match(1)
+          key = Regexp.last_match(2).strip
+          Regexp.last_match(3).strip
+
+          # Handle symbols (keys starting with :)
+          key = key.gsub(/^:/, "")
+
+          # Calculate depth based on indentation
+          depth = spaces.length / 2
+
+          # Adjust current path based on depth
+          current_path = current_path[0...depth]
+          current_path << key
+
+          # Build full key path
+          full_key = current_path.join(".")
+
+          # Record this occurrence
+          key_occurrences[full_key] << {
+            line:        line_number,
+            content:     line.strip,
+            parent_path: current_path[0...-1].join(".")
+          }
+        end
+      end
+
+      # Filter to find only duplicates
+      key_occurrences.each do |key, occurrences|
+        duplicates[key] = occurrences if occurrences.size > 1
+      end
+
+      duplicates
+    end
+
+    def format_duplicate_report(file, duplicates)
+      return nil if duplicates.empty?
+
+      report = ["File: #{file}"]
+      report << ("=" * 80)
+
+      duplicates.each do |key, occurrences|
+        report << "\nDuplicate key: '#{key}'"
+        report << "Found #{occurrences.size} times:"
+        occurrences.each do |occ|
+          report << "  Line #{occ[:line]}: #{occ[:content]}"
+        end
+      end
+
+      report.join("\n")
+    end
+
+    # Test each locale file
+    Rails.root.glob("config/locales/*.yml").each do |locale_file|
+      file_name = File.basename(locale_file)
+
+      it "#{file_name} should not have duplicate keys" do # rubocop:disable RSpec/NoExpectationExample
+        duplicates = find_duplicate_keys_with_line_numbers(locale_file)
+
+        if duplicates.any?
+          report = format_duplicate_report(locale_file, duplicates)
+          raise "Duplicate keys found in #{file_name}:\n\n#{report}\n"
+        end
+      end
+
+      it "#{file_name} should not mix symbol and string key styles" do # rubocop:disable RSpec/NoExpectationExample
+        symbol_keys = []
+        line_number = 0
+
+        File.foreach(locale_file) do |line|
+          line_number += 1
+
+          # Look for symbol-style keys (starting with :)
+          if line =~ /^( *):([^:]+):/
+            symbol_keys << {
+              line:    line_number,
+              content: line.strip,
+              key:     Regexp.last_match(2).strip
+            }
+          end
+        end
+
+        if symbol_keys.any?
+          report = ["File: #{locale_file}"]
+          report << ("=" * 80)
+          report << "\nFound symbol-style keys (these can cause override issues):"
+          symbol_keys.each do |sk|
+            report << "  Line #{sk[:line]}: #{sk[:content]}"
+          end
+
+          msg = "Symbol-style keys found in #{file_name}:\n\n#{report.join("\n")}\n\n"
+          msg += "These should be converted to string-style keys to avoid conflicts."
+          raise msg
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Backported i18n duplicates spec from pro edition to help detect translation issues early

## What this adds
- New spec that detects duplicate keys in YAML locale files
- Detection of symbol-style keys that should be string-style
- Prevents YAML override issues where duplicate keys silently overwrite each other

## Why this is important
This test helps catch translation bugs early by ensuring:
1. No duplicate keys exist in locale files (YAML silently uses the last definition)
2. No mixing of symbol and string key styles (can cause unexpected overrides)

## Testing
- Run `bundle exec rspec spec/i18n_duplicates_spec.rb`
- All 10 examples should pass for the basic edition locale files

## Note
The mail templates controller improvements from pro were not backported as they depend on multi-language support (locale column) which is not available in the basic edition.