### PR TITLE
[RailsBlueprint Basic] Add honeypot spam protection to contact form

### DIFF
--- a/app/assets/stylesheets/frontend/contact.scss
+++ b/app/assets/stylesheets/frontend/contact.scss
@@ -26,3 +26,12 @@
     margin: 100px 0;
   }
 }
+
+// Honeypot field - hidden from users to catch bots
+.contact-form-hp {
+  position: absolute;
+  left: -9999px;
+  opacity: 0;
+  height: 0;
+  overflow: hidden;
+}

--- a/app/commands/contact_us_command.rb
+++ b/app/commands/contact_us_command.rb
@@ -3,11 +3,30 @@ class ContactUsCommand < BaseCommand
   attribute :email, Types::String
   attribute :subject, Types::String
   attribute :message, Types::String
+  # Honeypot field - hidden from users, filled by bots
+  attribute :website, Types::String.optional
 
   validates_presence_of :name, :email, :subject, :message
 
   def process
-    send_notification
+    if bot_submission?
+      log_bot_submission
+    else
+      send_notification
+    end
+  end
+
+  private
+
+  def bot_submission?
+    website.present?
+  end
+
+  def log_bot_submission
+    Rails.logger.warn(
+      "[HONEYPOT] Bot submission detected - " \
+      "name: #{name}, email: #{email}, subject: #{subject}, website: #{website}"
+    )
   end
 
   def send_notification

--- a/app/views/contacts/_form.html.slim
+++ b/app/views/contacts/_form.html.slim
@@ -9,6 +9,9 @@ turbo-frame id="frame_#{dom_id(@command)}"
         = f.text_field :subject, hide_label: true, placeholder: t('.subject')
       .col-md-12
         = f.text_area :message, hide_label: true, placeholder: t('.message'), rows: 6
+      / Honeypot field - hidden from users, bots will fill it
+      .contact-form-hp
+        = f.text_field :website, hide_label: true, placeholder: "Website", tabindex: -1, autocomplete: "off"
       .col-md-12.text-center
         button type="submit" class="btn btn-primary"
           = t('actions.send_message')

--- a/spec/commands/contact_us_command_spec.rb
+++ b/spec/commands/contact_us_command_spec.rb
@@ -16,4 +16,41 @@ describe ContactUsCommand, type: :command do
     expect(TemplateMailer).to receive(:email).with(:contact_form_message, anything).and_call_original
     subject.call
   end
+
+  context "with honeypot field filled (bot submission)" do
+    let(:params) do
+      {
+        name: "Bot", email: "bot@spam.com", subject: "spam", message: "buy now",
+        website: "http://spam.com"
+      }
+    end
+
+    it "broadcasts ok" do
+      expect { subject.call }.to broadcast(:ok)
+    end
+
+    it "does not send email" do
+      expect(TemplateMailer).not_to receive(:email)
+      subject.call
+    end
+
+    it "logs the bot submission" do
+      expect(Rails.logger).to receive(:warn).with(/\[HONEYPOT\] Bot submission detected/)
+      subject.call
+    end
+  end
+
+  context "with empty honeypot field (legitimate submission)" do
+    let(:params) do
+      {
+        name: "User", email: "user@test.com", subject: "help", message: "me please",
+        website: ""
+      }
+    end
+
+    it "sends email" do
+      expect(TemplateMailer).to receive(:email).with(:contact_form_message, anything).and_call_original
+      subject.call
+    end
+  end
 end

--- a/spec/requests/contacts_spec.rb
+++ b/spec/requests/contacts_spec.rb
@@ -78,6 +78,29 @@ RSpec.describe "Contacts page" do
       end
     end
 
+    context "with honeypot field filled (bot submission)" do
+      let(:honeypot_params) {
+        {
+          contact_us_command: {
+            name:    "Bot",
+            email:   "bot@spam.com",
+            subject: "spam",
+            message: "buy now",
+            website: "http://spam.com"
+          }
+        }
+      }
+
+      it "returns http success" do
+        post "/contacts", params: honeypot_params
+        expect(response).to redirect_to("/contacts")
+      end
+
+      it "does not send email" do
+        expect { post "/contacts", params: honeypot_params }.not_to have_enqueued_mail
+      end
+    end
+
     context "as a trubostream" do
       let(:params) {
         {


### PR DESCRIPTION
## Summary
- Add hidden "website" field to contact form as honeypot for bots
- Bots typically fill all form fields, including hidden ones
- When honeypot is filled, log the submission and skip email sending
- Legitimate users never see or fill this field

## Changes
- ContactUsCommand: Added website attribute and bot detection logic
- contacts/_form.html.slim: Added hidden honeypot field
- contact.scss: CSS to hide the honeypot field from view
- Added unit and integration tests for honeypot functionality

## Test plan
- [x] Verify normal form submissions still work
- [x] Verify honeypot submissions are logged but do not send email
- [x] All tests pass