### PR TITLE
[RailsBlueprint Basic] Remove deprecated webdrivers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -186,6 +186,5 @@ group :test do
   gem "shoulda-matchers"
   gem "simplecov", require: false
   gem "spring-commands-rspec"
-  gem "webdrivers"
   gem "wisper-rspec"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -729,10 +729,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.3.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
     websocket (1.2.11)
     websocket-driver (0.8.0)
       base64
@@ -872,7 +868,6 @@ DEPENDENCIES
   view_component_reflex
   wannabe_bool (~> 0.7.1)
   web-console
-  webdrivers
   whenever (~> 1.0)
   wisper (~> 2.0)
   wisper-rspec


### PR DESCRIPTION
## Summary
- Remove deprecated webdrivers gem from test dependencies
- selenium-webdriver 4.11+ includes built-in Selenium Manager for automatic driver management
- Fixes SSL certificate verification issues during chromedriver downloads

## Changes
- Removed webdrivers gem from Gemfile

## Test plan
- [x] All 637 tests pass locally
- [x] System tests (login, homepage) work correctly